### PR TITLE
Hotsu/props

### DIFF
--- a/src/components/DrawTool.vue
+++ b/src/components/DrawTool.vue
@@ -16,7 +16,7 @@
 <script>
 export default {
   name: "DrawTool",
-  props: ['uploadedImage'],
+  props: ['uploadedImage',"canvasText"],
   data() {
     return {
       canvas: null,

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -7,7 +7,7 @@
         <h2>画像</h2>
         <img v-show="uploadedImage" :src="uploadedImage" />
         <input type="file" v-on:change="onFileChange">
-        <DrawTool :canvas-text="canvasText"/>
+        <DrawTool :canvas-text="canvasText" :uploadedImage="uploadedImage"/>
       </div>
 
 

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -7,7 +7,7 @@
         <h2>画像</h2>
         <img v-show="uploadedImage" :src="uploadedImage" />
         <input type="file" v-on:change="onFileChange">
-        <DrawTool />
+        <DrawTool :canvas-text="canvasText"/>
       </div>
 
 
@@ -33,6 +33,7 @@
           solo
           class="mx-auto"
           id="canvas_text"
+          v-model="canvasText"
         ></v-text-field>
         <!--
           <v-row>
@@ -178,6 +179,7 @@ export default {
   
   data: () => ({
     uploadedImage: '',
+    canvasText:""
   }),
   methods: {
     onFileChange(e) {


### PR DESCRIPTION
Propsを使って画像データとテキストをDrawTool.vueに渡せるようになりました。
![image](https://user-images.githubusercontent.com/45584045/109577499-03151e00-7b39-11eb-8253-ba4f0e333471.png)
